### PR TITLE
Switch expand icon to use same as core

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -101,7 +101,7 @@
 
     function addOverlays($elem) {
       $('iframe, video, .lazyYT', $elem).wrap("<div class='media-overlay-eligable'></div>")
-                .before("<button class='btn no-text control'>" + iconHTML('expand') + "</button>")
+                .before("<button class='btn no-text control'>" + iconHTML('discourse-expand') + "</button>")
                 .wrap("<div class='content'></div>");
 
       $( "button.control", $elem ).click(function() {


### PR DESCRIPTION
Sorry @davidtaylorhq, I forgot to include this in the previous PR. But since we switched the expand icon in core, this needs to be done in the component as well. Thanks!